### PR TITLE
Only addd userns if has a valid config

### DIFF
--- a/parse/config.go
+++ b/parse/config.go
@@ -285,7 +285,7 @@ func Config(c types.ContainerJSON, osType, architecture string, capabilities []s
 			Type: "pid",
 		})
 	}
-	if !c.HostConfig.NetworkMode.IsHost() && !c.HostConfig.PidMode.IsHost() && !c.HostConfig.Privileged {
+	if c.HostConfig.UsernsMode.Valid() && !c.HostConfig.NetworkMode.IsHost() && !c.HostConfig.PidMode.IsHost() && !c.HostConfig.Privileged {
 		config.Linux.Namespaces = append(config.Linux.Namespaces, specs.Namespace{
 			Type: "user",
 		})


### PR DESCRIPTION
This means it will not be defined on a container not running
in a userns, will be otherwise.

Fix #7

Signed-off-by: Justin Cormack <justin.cormack@docker.com>