### PR TITLE
Remove apparmor "unconfined" from the spec

### DIFF
--- a/parse/parse.go
+++ b/parse/parse.go
@@ -142,6 +142,11 @@ func parseSecurityOpt(config *specs.Spec, hc *containertypes.HostConfig) error {
 		config.Process.ApparmorProfile = "unconfined"
 	}
 
+	// runc does not like "unconfined" here
+	if config.Process.ApparmorProfile == "unconfined" {
+		config.Process.ApparmorProfile = ""
+	}
+
 	// set default seccomp profile if the user did not pass a custom profile
 	if !customSeccompProfile && !hc.Privileged {
 		config.Linux.Seccomp = &defaultSeccompProfile


### PR DESCRIPTION
runc does not like us to set "unconfined" as the apparmor
profile unfortunately.

Fix #8

Signed-off-by: Justin Cormack <justin.cormack@docker.com>